### PR TITLE
Show the destination folder name in the button text

### DIFF
--- a/src/_locales/de_DE/messages.json
+++ b/src/_locales/de_DE/messages.json
@@ -9,7 +9,13 @@
     "message": "QuickArchiver"
   },
   "toolbar.label.rule_present": {
-    "message": "QuickArchiver: Verschieben"
+    "message": "QuickArchiver: Verschieben in \"$folder$\"",
+    "placeholders": {
+      "folder": {
+        "content": "$1",
+        "example": "Blah"
+      }
+    }
   },
   "toolbar.title.rule_present": {
     "message": "Verschiebe \"$message$\" in Ordner \"$folder$\" (ALT+A)",

--- a/src/_locales/en_US/messages.json
+++ b/src/_locales/en_US/messages.json
@@ -9,7 +9,13 @@
     "message": "QuickArchiver"
   },
   "toolbar.label.rule_present": {
-    "message": "QuickArchiver: Move"
+    "message": "QuickArchiver: Move to \"$folder$\"",
+    "placeholders": {
+      "folder": {
+        "content": "$1",
+        "example": "Blah"
+      }
+    }
   },
   "toolbar.title.rule_present": {
     "message": "Move \"$message$\" to Folder \"$folder$\" (ALT+A)",

--- a/src/content/scripts/quickarchiver.js
+++ b/src/content/scripts/quickarchiver.js
@@ -435,7 +435,11 @@ let quickarchiver = {
                             rule.folder.path
                         ])
                     });
-                    messenger.messageDisplayAction.setLabel({label: browser.i18n.getMessage("toolbar.label.rule_present")});
+                    messenger.messageDisplayAction.setLabel({
+                        label: browser.i18n.getMessage("toolbar.label.rule_present", [
+                            rule.folder.name
+                        ])
+                    });
                 }
 
                 await messenger.menus.update(this.toolbarMenuEditRuleId, {enabled: true});


### PR DESCRIPTION
Needing a quick "at a glance" indication of where the mail would be moved too, this update shows the folder name in the button label, leaving the full path in the title.
![image](https://github.com/user-attachments/assets/ae4779ed-ca62-4c89-9d6c-d09b4c227e02)

I hope this is acceptable, but please let me know of any questions.